### PR TITLE
Centralize avatar color helper

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { User, Mail, Lock, Eye, EyeOff } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { getRandomColor } from '../utils/avatarColors';
 
 interface AuthFormProps {
   onAuthSuccess: (user: any) => void;
@@ -91,14 +92,6 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps) {
     }
   };
 
-  const getRandomColor = () => {
-    const colors = [
-      '#EF4444', '#F97316', '#F59E0B', '#84CC16', 
-      '#22C55E', '#06B6D4', '#3B82F6', '#6366F1', 
-      '#8B5CF6', '#EC4899', '#F43F5E', '#64748B'
-    ];
-    return colors[Math.floor(Math.random() * colors.length)];
-  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-purple-900 flex items-center justify-center p-4">

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { X, User, Mail, Palette, Save, Upload } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { ChatHeader } from './ChatHeader';
+import { avatarColors } from '../utils/avatarColors';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -17,12 +18,6 @@ interface UserProfileProps {
   currentPage: PageType;
   onPageChange: (page: PageType) => void;
 }
-
-const avatarColors = [
-  '#EF4444', '#F97316', '#F59E0B', '#84CC16', 
-  '#22C55E', '#06B6D4', '#3B82F6', '#6366F1', 
-  '#8B5CF6', '#EC4899', '#F43F5E', '#64748B'
-];
 
 export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageChange }: UserProfileProps) {
   const [profileData, setProfileData] = useState({

--- a/src/components/UserSetup.tsx
+++ b/src/components/UserSetup.tsx
@@ -1,20 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { User } from 'lucide-react';
 import { User as UserType } from '../types/message';
+import { getRandomColor } from '../utils/avatarColors';
 
 interface UserSetupProps {
   onUserSet: (user: UserType) => void;
 }
 
-const avatarColors = [
-  '#EF4444', '#F97316', '#F59E0B', '#84CC16', 
-  '#22C55E', '#06B6D4', '#3B82F6', '#6366F1', 
-  '#8B5CF6', '#EC4899', '#F43F5E', '#64748B'
-];
-
-const getRandomColor = () => {
-  return avatarColors[Math.floor(Math.random() * avatarColors.length)];
-};
 
 export function UserSetup({ onUserSet }: UserSetupProps) {
   const [name, setName] = useState('');

--- a/src/utils/avatarColors.ts
+++ b/src/utils/avatarColors.ts
@@ -1,0 +1,9 @@
+export const avatarColors = [
+  '#EF4444', '#F97316', '#F59E0B', '#84CC16',
+  '#22C55E', '#06B6D4', '#3B82F6', '#6366F1',
+  '#8B5CF6', '#EC4899', '#F43F5E', '#64748B'
+];
+
+export const getRandomColor = () => {
+  return avatarColors[Math.floor(Math.random() * avatarColors.length)];
+};


### PR DESCRIPTION
## Summary
- add shared `avatarColors` utility
- use the helper in `AuthForm`, `UserSetup`, and `UserProfile`
- remove redundant color arrays

## Testing
- `npm run lint` *(fails: `@typescript-eslint` errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68555788c7d083279478dd5bc822fce8