### PR TITLE
Centralize avatar colors

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { User, Mail, Lock, Eye, EyeOff } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { AVATAR_COLORS, DEFAULT_AVATAR_COLOR } from '../utils/avatarColors';
 
 interface AuthFormProps {
   onAuthSuccess: (user: any) => void;
@@ -41,7 +42,7 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps) {
           id: data.user.id,
           email: data.user.email,
           username: profile?.username || email.split('@')[0],
-          avatar_color: profile?.avatar_color || '#3B82F6',
+          avatar_color: profile?.avatar_color || DEFAULT_AVATAR_COLOR,
         });
       } else {
         // Sign up new user
@@ -92,12 +93,7 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps) {
   };
 
   const getRandomColor = () => {
-    const colors = [
-      '#EF4444', '#F97316', '#F59E0B', '#84CC16', 
-      '#22C55E', '#06B6D4', '#3B82F6', '#6366F1', 
-      '#8B5CF6', '#EC4899', '#F43F5E', '#64748B'
-    ];
-    return colors[Math.floor(Math.random() * colors.length)];
+    return AVATAR_COLORS[Math.floor(Math.random() * AVATAR_COLORS.length)];
   };
 
   return (

--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useLayoutEffect, useMemo } from 'react';
 import { Search, MessageSquare, Send, X, Clock, Users, ArrowLeft } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { DEFAULT_AVATAR_COLOR } from '../utils/avatarColors';
 import { VirtualizedMessageList, VirtualizedMessageListHandle } from './VirtualizedMessageList';
 
 interface User {
@@ -257,7 +258,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], ma
     return users.find(u => u.id === otherUser.id) || {
       id: otherUser.id,
       username: otherUser.username,
-      avatar_color: '#3B82F6'
+      avatar_color: DEFAULT_AVATAR_COLOR
     };
   };
 

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { X, User, Mail, Palette, Save, Upload } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { ChatHeader } from './ChatHeader';
+import { AVATAR_COLORS } from '../utils/avatarColors';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -18,11 +19,7 @@ interface UserProfileProps {
   onPageChange: (page: PageType) => void;
 }
 
-const avatarColors = [
-  '#EF4444', '#F97316', '#F59E0B', '#84CC16', 
-  '#22C55E', '#06B6D4', '#3B82F6', '#6366F1', 
-  '#8B5CF6', '#EC4899', '#F43F5E', '#64748B'
-];
+const avatarColors = AVATAR_COLORS;
 
 export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageChange }: UserProfileProps) {
   const [profileData, setProfileData] = useState({

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { DEFAULT_AVATAR_COLOR } from '../utils/avatarColors';
 import { User } from '@supabase/supabase-js';
 
 interface AuthUser {
@@ -55,7 +56,7 @@ export function useAuth() {
         id: authUser.id,
         email: authUser.email || '',
         username: profile?.username || authUser.email?.split('@')[0] || 'User',
-        avatar_color: profile?.avatar_color || '#3B82F6',
+        avatar_color: profile?.avatar_color || DEFAULT_AVATAR_COLOR,
       });
     } catch (error) {
       console.error('Error fetching user profile:', error);
@@ -63,7 +64,7 @@ export function useAuth() {
         id: authUser.id,
         email: authUser.email || '',
         username: authUser.email?.split('@')[0] || 'User',
-        avatar_color: '#3B82F6',
+        avatar_color: DEFAULT_AVATAR_COLOR,
       });
     } finally {
       setLoading(false);

--- a/src/utils/avatarColors.ts
+++ b/src/utils/avatarColors.ts
@@ -1,0 +1,7 @@
+export const AVATAR_COLORS = [
+  '#EF4444', '#F97316', '#F59E0B', '#84CC16',
+  '#22C55E', '#06B6D4', '#3B82F6', '#6366F1',
+  '#8B5CF6', '#EC4899', '#F43F5E', '#64748B'
+];
+
+export const DEFAULT_AVATAR_COLOR = '#3B82F6';


### PR DESCRIPTION
## Summary
- centralize avatar color constants
- use shared constants in auth form, user profile, DM page, and auth hook

## Testing
- `npm run lint` *(fails: cannot pass existing lint issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68555ae2c8c48327b1862ce022bab126