### PR TITLE
Add Supabase env var check

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,9 +1,16 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || '';
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+if (!supabaseUrl || !supabaseAnonKey) {
+  const missing: string[] = [];
+  if (!supabaseUrl) missing.push('VITE_SUPABASE_URL');
+  if (!supabaseAnonKey) missing.push('VITE_SUPABASE_ANON_KEY');
+  throw new Error(`Missing environment variables: ${missing.join(', ')}`);
+}
+
+export const supabase = createClient(supabaseUrl as string, supabaseAnonKey as string);
 
 export interface Database {
   public: {


### PR DESCRIPTION
## Summary
- ensure `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are defined before creating the Supabase client

## Testing
- `npm run lint` *(fails: cannot satisfy ESLint rules)*

------
https://chatgpt.com/codex/tasks/task_e_68555e9191c08327ac332c241eb5503c