### PR TITLE
Implement push subscription storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { NotificationBanner } from './components/NotificationBanner';
 import { useMessages } from './hooks/useMessages';
 import { useAuth } from './hooks/useAuth';
 import { useDMNotifications } from './hooks/useDMNotifications';
+import { usePushSubscription } from './hooks/usePushSubscription';
 import { LoadingSpinner } from './components/LoadingSpinner';
 import { supabase } from './lib/supabase';
 
@@ -37,6 +38,8 @@ function App() {
     clearBanner,
     markAsRead,
   } = useDMNotifications(user?.id ?? null, currentPage, activeConversationId);
+
+  usePushSubscription(user?.id ?? null);
 
   // Show loading spinner while checking auth
   if (authLoading) {

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { supabase } from '../lib/supabase';
+
+export function usePushSubscription(userId: string | null) {
+  useEffect(() => {
+    if (!userId) return;
+    const subscribe = async () => {
+      if (!('serviceWorker' in navigator)) return;
+      try {
+        const permission = await Notification.requestPermission();
+        if (permission !== 'granted') return;
+
+        const registration = await navigator.serviceWorker.ready;
+        const existing = await registration.pushManager.getSubscription();
+        const sub =
+          existing ||
+          (await registration.pushManager.subscribe({ userVisibleOnly: true }));
+
+        if (!sub) return;
+
+        const { error } = await supabase
+          .from('subscriptions')
+          .insert({ user_id: userId, subscription: sub });
+
+        if (error) console.error('Error saving subscription:', error);
+      } catch (err) {
+        console.error('Failed to subscribe to push notifications', err);
+      }
+    };
+
+    subscribe();
+  }, [userId]);
+}


### PR DESCRIPTION
## Summary
- implement new `usePushSubscription` hook to request notification permission and subscribe to push
- invoke the hook from `App` so the subscription is saved in Supabase

## Testing
- `npm run lint` *(fails: cannot pass existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855630747ec83279ece3db4387a81e8