### PR TITLE
Improve typings and hook dependencies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { AuthForm } from './components/AuthForm';
 import { ChatHeader } from './components/ChatHeader';
 import { ChatArea } from './components/ChatArea';
@@ -60,7 +60,6 @@ function App() {
     return (
       <UserProfile
         user={user}
-        onClose={() => setCurrentPage('group-chat')}
         onUserUpdate={updateUser}
         currentPage={currentPage}
         onPageChange={setCurrentPage}

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import { User, Mail, Lock, Eye, EyeOff } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { AVATAR_COLORS, DEFAULT_AVATAR_COLOR } from '../utils/avatarColors';
+import type { AuthUser } from '../hooks/useAuth';
 
 interface AuthFormProps {
-  onAuthSuccess: (user: any) => void;
+  onAuthSuccess: (user: AuthUser) => void;
 }
 
 export function AuthForm({ onAuthSuccess }: AuthFormProps) {

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -101,25 +101,6 @@ export function ChatArea({
     };
   }, [handleScroll]);
 
-  if (loading && messages.length === 0) {
-    return <LoadingSpinner />;
-  }
-
-  if (error) {
-    return <ErrorMessage message={error} onRetry={onRetry} />;
-  }
-
-  if (messages.length === 0) {
-    return (
-      <div className="flex items-center justify-center p-8 text-center flex-1">
-        <div>
-          <p className="text-gray-400 text-lg mb-2">No messages yet</p>
-          <p className="text-gray-500">Be the first to say hello! 👋</p>
-        </div>
-      </div>
-    );
-  }
-
   const items = useMemo(() => {
     const arr: { key: string; element: JSX.Element }[] = [];
     let lastDateLabel: string | null = null;
@@ -153,6 +134,25 @@ export function ChatArea({
 
     return arr;
   }, [messages, currentUserId, onUserClick]);
+
+  if (loading && messages.length === 0) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={onRetry} />;
+  }
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-8 text-center flex-1">
+        <div>
+          <p className="text-gray-400 text-lg mb-2">No messages yet</p>
+          <p className="text-gray-500">Be the first to say hello! 👋</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <VirtualizedMessageList

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { LogOut, User, UserCircle, Users, MessageCircle, Menu, X } from 'lucide-react';
+import { LogOut, UserCircle, Users, MessageCircle, Menu, X } from 'lucide-react';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 

--- a/src/components/ProfilePreviewModal.tsx
+++ b/src/components/ProfilePreviewModal.tsx
@@ -24,30 +24,30 @@ export function ProfilePreviewModal({ userId, onClose }: ProfilePreviewModalProp
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const fetchUserProfile = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const { data, error } = await supabase
+          .from('users')
+          .select('id, username, email, bio, avatar_color, avatar_url, banner_url, created_at')
+          .eq('id', userId)
+          .single();
+
+        if (error) throw error;
+
+        setProfile(data);
+      } catch (err) {
+        console.error('Error fetching user profile:', err);
+        setError('Failed to load user profile');
+      } finally {
+        setLoading(false);
+      }
+    };
+
     fetchUserProfile();
   }, [userId]);
-
-  const fetchUserProfile = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, username, email, bio, avatar_color, avatar_url, banner_url, created_at')
-        .eq('id', userId)
-        .single();
-
-      if (error) throw error;
-
-      setProfile(data);
-    } catch (err) {
-      console.error('Error fetching user profile:', err);
-      setError('Failed to load user profile');
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const formatJoinDate = (dateString: string) => {
     if (!dateString) return 'Unknown';

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,7 +3,7 @@ import { supabase } from '../lib/supabase';
 import { DEFAULT_AVATAR_COLOR } from '../utils/avatarColors';
 import { User } from '@supabase/supabase-js';
 
-interface AuthUser {
+export interface AuthUser {
   id: string;
   email: string;
   username: string;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
+import type { DMMessage } from '../types/dm';
+
+interface PushSubscriptionData {
+  endpoint: string;
+  expirationTime: number | null;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -83,19 +93,19 @@ export interface Database {
         Row: {
           id: string;
           user_id: string | null;
-          subscription: any;
+          subscription: PushSubscriptionData;
           created_at: string | null;
         };
         Insert: {
           id?: string;
           user_id?: string | null;
-          subscription: any;
+          subscription: PushSubscriptionData;
           created_at?: string | null;
         };
         Update: {
           id?: string;
           user_id?: string | null;
-          subscription?: any;
+          subscription?: PushSubscriptionData;
           created_at?: string | null;
         };
       };
@@ -106,7 +116,7 @@ export interface Database {
           user2_id: string;
           user1_username: string;
           user2_username: string;
-          messages: any | null;
+          messages: DMMessage[] | null;
           created_at: string | null;
           updated_at: string | null;
         };
@@ -116,7 +126,7 @@ export interface Database {
           user2_id: string;
           user1_username: string;
           user2_username: string;
-          messages?: any | null;
+          messages?: DMMessage[] | null;
           created_at?: string | null;
           updated_at?: string | null;
         };
@@ -126,7 +136,7 @@ export interface Database {
           user2_id?: string;
           user1_username?: string;
           user2_username?: string;
-          messages?: any | null;
+          messages?: DMMessage[] | null;
           created_at?: string | null;
           updated_at?: string | null;
         };

--- a/src/types/dm.ts
+++ b/src/types/dm.ts
@@ -1,0 +1,17 @@
+export interface DMMessage {
+  id: string;
+  sender_id: string;
+  content: string;
+  created_at: string;
+}
+
+export interface DMConversation {
+  id: string;
+  user1_id: string;
+  user2_id: string;
+  user1_username: string;
+  user2_username: string;
+  messages: DMMessage[];
+  updated_at: string;
+}
+


### PR DESCRIPTION
## Summary
- add shared types for DM messages
- type authentication user hooks and components
- enforce safer database types
- restructure ChatArea hooks
- refactor DM page effects and callbacks
- inline profile data loaders for cleaner dependencies

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855666e9f188327a9269b959f511e1f