### PR TITLE
Add push event error handling

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -3,10 +3,17 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('push', event => {
-  const data = event.data ? event.data.json() : {};
-  const title = data.title || 'New message';
+  let data = {};
+  if (event.data) {
+    try {
+      data = event.data.json();
+    } catch (err) {
+      console.error('Failed to parse push event data as JSON:', err);
+    }
+  }
+  const title = typeof data.title === 'string' && data.title.trim() !== '' ? data.title : 'New message';
   const options = {
-    body: data.body,
+    body: typeof data.body === 'string' ? data.body : '',
     icon: '/favicon.ico',
   };
   event.waitUntil(self.registration.showNotification(title, options));


### PR DESCRIPTION
## Summary
- improve push event parsing in the service worker

## Testing
- `npm run lint` *(fails: cannot parse existing source files)*

------
https://chatgpt.com/codex/tasks/task_e_68556682859c832794042d5b45e242cf