### PR TITLE
Fix message virtualization layout

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -112,7 +112,7 @@ export function ChatArea({
         arr.push({
           key: `date-${dateLabel}-${message.id}`,
           element: (
-            <div className="my-4">
+            <div className="py-4">
               <DateDivider label={dateLabel} />
             </div>
           ),
@@ -123,11 +123,13 @@ export function ChatArea({
       arr.push({
         key: message.id,
         element: (
-          <MessageBubble
-            message={message}
-            isOwnMessage={message.user_id === currentUserId}
-            onUserClick={onUserClick}
-          />
+          <div className="pb-3 sm:pb-4">
+            <MessageBubble
+              message={message}
+              isOwnMessage={message.user_id === currentUserId}
+              onUserClick={onUserClick}
+            />
+          </div>
         ),
       });
     });

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -16,7 +16,7 @@ export function MessageBubble({ message, isOwnMessage, onUserClick }: MessageBub
   };
 
   return (
-    <div className={`flex gap-2 sm:gap-3 mb-3 sm:mb-4 ${isOwnMessage ? 'flex-row-reverse' : ''}`}>
+    <div className={`flex gap-2 sm:gap-3 ${isOwnMessage ? 'flex-row-reverse' : ''}`}>
       <button
         onClick={() => onUserClick?.(message.user_id)}
         className="w-7 h-7 sm:w-8 sm:h-8 rounded-full flex items-center justify-center text-white text-xs sm:text-sm font-medium flex-shrink-0 hover:ring-2 hover:ring-blue-400 transition-all cursor-pointer overflow-hidden relative"

--- a/src/components/VirtualizedMessageList.tsx
+++ b/src/components/VirtualizedMessageList.tsx
@@ -1,4 +1,9 @@
-import React, { useRef, useLayoutEffect, forwardRef, useImperativeHandle } from 'react';
+import React, {
+  useRef,
+  useLayoutEffect,
+  forwardRef,
+  useImperativeHandle,
+} from 'react';
 import { VariableSizeList as List } from 'react-window';
 
 interface Item {
@@ -38,8 +43,20 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
       const rowRef = useRef<HTMLDivElement>(null);
 
       useLayoutEffect(() => {
-        const height = rowRef.current?.getBoundingClientRect().height ?? 80;
-        setSize(index, height);
+        const node = rowRef.current;
+        if (!node) return;
+
+        const measure = () => {
+          const height = node.getBoundingClientRect().height;
+          setSize(index, height);
+        };
+
+        measure();
+
+        const observer = new ResizeObserver(measure);
+        observer.observe(node);
+
+        return () => observer.disconnect();
       }, [index]);
 
       return (
@@ -60,6 +77,7 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
         height={height}
         itemCount={items.length}
         itemSize={getSize}
+        itemKey={(index) => items[index].key}
         width="100%"
         ref={listRef}
         outerRef={outerRef}


### PR DESCRIPTION
## Summary
- ensure list items maintain spacing with padding wrappers
- keep message bubbles margin-free
- observe message rows and update their heights
- use stable keys for virtualization

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685578a96bb083278556399119c278f1