### PR TITLE
Improve notification pop-up

### DIFF
--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { X } from 'lucide-react';
 
 interface BannerProps {
   notification: {
@@ -21,10 +22,22 @@ export function NotificationBanner({ notification, onClose, onClick }: BannerPro
 
   return (
     <div
-      onClick={() => onClick?.(notification.conversationId)}
-      className="fixed top-16 inset-x-0 sm:top-16 sm:right-4 sm:left-auto sm:w-80 bg-gray-800/90 border border-gray-700 text-white px-4 py-2 rounded-none sm:rounded-lg shadow-xl z-50 cursor-pointer hover:bg-gray-700/90 transition-colors"
+      onClick={() => {
+        onClick?.(notification.conversationId);
+        onClose();
+      }}
+      className="fixed top-16 inset-x-0 sm:top-16 sm:right-4 sm:left-auto sm:w-[30rem] bg-gradient-to-r from-blue-600 to-purple-700 border border-gray-700 text-white px-6 py-3 rounded-none sm:rounded-lg shadow-xl z-50 cursor-pointer hover:from-blue-500 hover:to-purple-600 transition-colors"
     >
-      <p className="text-sm truncate">
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+        className="absolute top-2 right-2 text-white hover:text-gray-200"
+      >
+        <X className="w-4 h-4" />
+      </button>
+      <p className="text-base truncate pr-6">
         <span className="font-semibold mr-1">{notification.senderUsername}:</span>
         {notification.content}
       </p>


### PR DESCRIPTION
## Summary
- make notification banner stand out with blue-purple gradient
- increase banner size and padding
- add exit button
- hide banner when navigating to conversation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557fe10fa883278e2f0430f13e8bb1