### PR TITLE
Fix message bubble layout

### DIFF
--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -50,8 +50,8 @@ export function MessageBubble({ message, isOwnMessage, onUserClick }: MessageBub
         )}
       </button>
       
-      <div className={`flex flex-col ${isOwnMessage ? 'items-end' : 'items-start'} max-w-[200px] sm:max-w-xs md:max-w-md min-w-0`}>
-        <div className={`px-4 py-2 rounded-2xl ${
+      <div className={`flex flex-col flex-1 ${isOwnMessage ? 'items-end' : 'items-start'} min-w-0`}>
+        <div className={`px-4 py-2 rounded-2xl w-full ${
           isOwnMessage
             ? 'bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-br-md shadow-lg'
             : 'bg-gray-700 text-gray-100 rounded-bl-md shadow-lg border border-gray-600'

--- a/src/index.css
+++ b/src/index.css
@@ -66,4 +66,8 @@
     overflow-wrap: break-word;
     hyphens: auto;
   }
+
+  .overflow-wrap-anywhere {
+    overflow-wrap: anywhere;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure message bubbles take up available width
- add CSS class for breaking long words

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855801432d88327a2a313f11a005a2a