### PR TITLE
Update subscription logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
     sendMessage,
     fetchOlderMessages,
     hasMore,
-  } = useMessages(user?.id ?? null); // Pass user ID but hook will work regardless
+  } = useMessages();
 
   const {
     unreadConversations,

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -4,7 +4,7 @@ import { Message } from '../types/message';
 
 const PAGE_SIZE = 20;
 
-export function useMessages(userId: string | null) {
+export function useMessages() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingOlder, setLoadingOlder] = useState(false);

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -18,11 +18,48 @@ export function usePushSubscription(userId: string | null) {
 
         if (!sub) return;
 
-        const { error } = await supabase
+        // Check for existing subscription for this user
+        const { data: existingRow, error: selectError } = await supabase
           .from('subscriptions')
-          .insert({ user_id: userId, subscription: sub });
+          .select('id')
+          .eq('user_id', userId)
+          .single();
 
-        if (error) console.error('Error saving subscription:', error);
+        if (selectError && selectError.code !== 'PGRST116') {
+          console.error('Error checking subscription:', selectError);
+          return;
+        }
+
+        if (existingRow) {
+          // Update existing record
+          const { error: updateError } = await supabase
+            .from('subscriptions')
+            .update({ subscription: sub })
+            .eq('id', existingRow.id);
+          if (updateError) {
+            console.error('Error updating subscription:', updateError);
+          }
+        } else {
+          // Insert new record
+          const { error: insertError } = await supabase
+            .from('subscriptions')
+            .insert({ user_id: userId, subscription: sub });
+
+          if (insertError) {
+            if (insertError.code === '23505') {
+              // Unique constraint failed, update instead
+              const { error: updateError } = await supabase
+                .from('subscriptions')
+                .update({ subscription: sub })
+                .eq('user_id', userId);
+              if (updateError) {
+                console.error('Error updating subscription:', updateError);
+              }
+            } else {
+              console.error('Error saving subscription:', insertError);
+            }
+          }
+        }
       } catch (err) {
         console.error('Failed to subscribe to push notifications', err);
       }


### PR DESCRIPTION
## Summary
- avoid storing multiple subscriptions per user
- adjust message hook signature

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68559085c2a0832783a2a168796b3469