### PR TITLE
Cache avatar_url after login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ import { useAuth } from './hooks/useAuth';
 import { useDMNotifications } from './hooks/useDMNotifications';
 import { usePushSubscription } from './hooks/usePushSubscription';
 import { LoadingSpinner } from './components/LoadingSpinner';
-import { supabase } from './lib/supabase';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -75,14 +74,13 @@ function App() {
 
   const handleSendMessage = async (content: string) => {
     if (user) {
-      // Get the latest user data including avatar_url
-      const { data: userData } = await supabase
-        .from('users')
-        .select('avatar_url')
-        .eq('id', user.id)
-        .single();
-      
-      await sendMessage(content, user.username, user.id, user.avatar_color, userData?.avatar_url || null);
+      await sendMessage(
+        content,
+        user.username,
+        user.id,
+        user.avatar_color,
+        user.avatar_url
+      );
     }
   };
 

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -44,6 +44,7 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps) {
           email: data.user.email,
           username: profile?.username || email.split('@')[0],
           avatar_color: profile?.avatar_color || DEFAULT_AVATAR_COLOR,
+          avatar_url: profile?.avatar_url || null,
         });
       } else {
         // Sign up new user
@@ -83,6 +84,7 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps) {
             email: data.user.email,
             username: username.trim(),
             avatar_color: avatarColor,
+            avatar_url: null,
           });
         }
       }

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -8,12 +8,7 @@ import type { AuthUser } from '../hooks/useAuth';
 type PageType = 'group-chat' | 'dms' | 'profile';
 
 interface UserProfileProps {
-  user: {
-    id: string;
-    email: string;
-    username: string;
-    avatar_color: string;
-  };
+  user: AuthUser;
   onUserUpdate: (updatedUser: AuthUser) => void;
   currentPage: PageType;
   onPageChange: (page: PageType) => void;
@@ -129,6 +124,7 @@ export function UserProfile({ user, onUserUpdate, currentPage, onPageChange }: U
         ...user,
         username: editData.username.trim(),
         avatar_color: editData.avatar_color,
+        avatar_url: editData.avatar_url.trim() || null,
       });
 
       setSuccess(true);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -8,6 +8,7 @@ export interface AuthUser {
   email: string;
   username: string;
   avatar_color: string;
+  avatar_url: string | null;
 }
 
 export function useAuth() {
@@ -48,7 +49,7 @@ export function useAuth() {
     try {
       const { data: profile } = await supabase
         .from('users')
-        .select('username, avatar_color')
+        .select('username, avatar_color, avatar_url')
         .eq('id', authUser.id)
         .single();
 
@@ -57,6 +58,7 @@ export function useAuth() {
         email: authUser.email || '',
         username: profile?.username || authUser.email?.split('@')[0] || 'User',
         avatar_color: profile?.avatar_color || DEFAULT_AVATAR_COLOR,
+        avatar_url: profile?.avatar_url || null,
       });
     } catch (error) {
       console.error('Error fetching user profile:', error);
@@ -65,6 +67,7 @@ export function useAuth() {
         email: authUser.email || '',
         username: authUser.email?.split('@')[0] || 'User',
         avatar_color: DEFAULT_AVATAR_COLOR,
+        avatar_url: null,
       });
     } finally {
       setLoading(false);

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -4,7 +4,8 @@ import { Message } from '../types/message';
 
 const PAGE_SIZE = 20;
 
-export function useMessages(userId: string | null) {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function useMessages(_userId: string | null) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingOlder, setLoadingOlder] = useState(false);


### PR DESCRIPTION
## Summary
- store `avatar_url` in `useAuth`
- avoid re-querying Supabase in `handleSendMessage`
- include avatar URL when saving profile or auth results
- keep lint happy in `useMessages`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68559083300c83278f64614a7cb3bf67