### PR TITLE
Fix chat history display

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -131,7 +131,7 @@ export function ChatArea({
       });
     }
 
-    messages.forEach((message, index) => {
+    messages.forEach((message) => {
       const dateLabel = formatDateGroup(message.created_at);
 
       if (dateLabel !== lastDateLabel) {

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -165,13 +165,15 @@ export function useMessages() {
 
       console.log('Message sent successfully:', data);
 
-      // The realtime subscription will handle adding the message to the state
-      // But we'll also update the latest timestamp
-      if (data && (
-        !latestTimestampRef.current ||
-        new Date(data.created_at) > new Date(latestTimestampRef.current)
-      )) {
-        latestTimestampRef.current = data.created_at;
+      if (data) {
+        // Optimistically add the message to local state in case realtime
+        // updates are not received due to configuration issues
+        setMessages(prev => [...prev, data]);
+
+        if (!latestTimestampRef.current ||
+            new Date(data.created_at) > new Date(latestTimestampRef.current)) {
+          latestTimestampRef.current = data.created_at;
+        }
       }
     } catch (err) {
       console.error('Error sending message:', err);


### PR DESCRIPTION
## Summary
- remove unused `index` variable from `ChatArea`
- optimistically add sent messages in `useMessages`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68559382dce88327a4afb0b1da1617eb