### PR TITLE
Add message hearts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ function App() {
     loadingOlder,
     error,
     sendMessage,
+    heartMessage,
     fetchOlderMessages,
     hasMore,
   } = useMessages();
@@ -159,6 +160,7 @@ function App() {
           fetchOlderMessages={fetchOlderMessages}
           hasMore={hasMore}
           onUserClick={handleUserClick}
+          onHeartMessage={heartMessage}
         />
       </div>
 

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -22,6 +22,7 @@ interface ChatAreaProps {
   fetchOlderMessages: () => void;
   hasMore: boolean;
   onUserClick?: (userId: string) => void;
+  onHeartMessage?: (id: string, count: number) => void;
 }
 
 export function ChatArea({
@@ -34,6 +35,7 @@ export function ChatArea({
   fetchOlderMessages,
   hasMore,
   onUserClick,
+  onHeartMessage,
 }: ChatAreaProps) {
   console.log('ChatArea render:', { 
     messagesCount: messages.length, 
@@ -145,13 +147,16 @@ export function ChatArea({
             message={message}
             isOwnMessage={message.user_id === currentUserId}
             onUserClick={onUserClick}
+            onHeart={() =>
+              onHeartMessage?.(message.id, message.hearts_count ?? 0)
+            }
           />
         </div>
       );
     });
 
     return items;
-  }, [messages, currentUserId, onUserClick, hasMore, loadingOlder]);
+  }, [messages, currentUserId, onUserClick, onHeartMessage, hasMore, loadingOlder]);
 
   if (loading && messages.length === 0) {
     console.log('Showing loading spinner');

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
+import { Heart } from 'lucide-react';
 import { Message } from '../types/message';
 
 interface MessageBubbleProps {
   message: Message;
   isOwnMessage: boolean;
   onUserClick?: (userId: string) => void;
+  onHeart?: () => void;
 }
 
-export function MessageBubble({ message, isOwnMessage, onUserClick }: MessageBubbleProps) {
+export function MessageBubble({ message, isOwnMessage, onUserClick, onHeart }: MessageBubbleProps) {
   const formatTime = (timestamp: string) => {
     return new Date(timestamp).toLocaleTimeString([], { 
       hour: '2-digit', 
@@ -65,6 +67,18 @@ export function MessageBubble({ message, isOwnMessage, onUserClick }: MessageBub
           <span className="font-medium text-xs">{message.user_name}</span>
           <span>•</span>
           <span className="text-xs">{formatTime(message.created_at)}</span>
+          <button
+            onClick={onHeart}
+            className="ml-2 flex items-center gap-1 text-gray-400 hover:text-red-500 transition-colors"
+          >
+            <Heart
+              className="w-3 h-3"
+              fill={message.hearts_count && message.hearts_count > 0 ? 'currentColor' : 'none'}
+            />
+            {message.hearts_count ? (
+              <span>{message.hearts_count}</span>
+            ) : null}
+          </button>
         </div>
       </div>
     </div>

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -78,7 +78,7 @@ export function useMessages() {
 
       const { data, error } = await supabase
         .from('messages')
-        .select('id, content, user_name, user_id, avatar_color, avatar_url, created_at')
+        .select('id, content, user_name, user_id, avatar_color, avatar_url, hearts_count, created_at')
         .order('created_at', { ascending: false })
         .limit(PAGE_SIZE);
 
@@ -125,7 +125,7 @@ export function useMessages() {
     try {
       const { data, error } = await supabase
         .from('messages')
-        .select('id, content, user_name, user_id, avatar_color, avatar_url, created_at')
+        .select('id, content, user_name, user_id, avatar_color, avatar_url, hearts_count, created_at')
         .lt('created_at', oldestTimestampRef.current)
         .order('created_at', { ascending: false })
         .limit(PAGE_SIZE);
@@ -179,8 +179,9 @@ export function useMessages() {
           user_id: userId,
           avatar_color: avatarColor,
           avatar_url: avatarUrl,
+          hearts_count: 0,
         })
-        .select('id, content, user_name, user_id, avatar_color, avatar_url, created_at')
+        .select('id, content, user_name, user_id, avatar_color, avatar_url, hearts_count, created_at')
         .single();
 
       if (error) throw error;
@@ -204,12 +205,27 @@ export function useMessages() {
     }
   };
 
+  const heartMessage = async (id: string, currentCount: number = 0) => {
+    const newCount = currentCount + 1;
+    setMessages(prev =>
+      prev.map(m => (m.id === id ? { ...m, hearts_count: newCount } : m))
+    );
+    const { error } = await supabase
+      .from('messages')
+      .update({ hearts_count: newCount })
+      .eq('id', id);
+    if (error) {
+      console.error('Failed to heart message:', error);
+    }
+  };
+
   return {
     messages,
     loading,
     loadingOlder,
     error,
     sendMessage,
+    heartMessage,
     fetchOlderMessages,
     hasMore,
   };

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -76,6 +76,7 @@ export interface Database {
           avatar_color: string;
           created_at: string | null;
           avatar_url: string | null;
+          hearts_count: number | null;
         };
         Insert: {
           id?: string;
@@ -85,6 +86,7 @@ export interface Database {
           avatar_color?: string;
           created_at?: string | null;
           avatar_url?: string | null;
+          hearts_count?: number | null;
         };
         Update: {
           id?: string;
@@ -94,6 +96,7 @@ export interface Database {
           avatar_color?: string;
           created_at?: string | null;
           avatar_url?: string | null;
+          hearts_count?: number | null;
         };
       };
       subscriptions: {

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -6,6 +6,7 @@ export interface Message {
   created_at: string;
   avatar_color: string;
   avatar_url?: string | null;
+  hearts_count?: number;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- allow heart reactions on messages
- update message database types
- handle heart updates in message hooks
- show heart button on each message

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a37f6c20832794eefde1db5d110f